### PR TITLE
Sets the height of a tile when placing a tree.

### DIFF
--- a/src/com/wurmonline/wurmapi/api/WurmMapUploader.java
+++ b/src/com/wurmonline/wurmapi/api/WurmMapUploader.java
@@ -363,6 +363,7 @@ public class WurmMapUploader {
 				// set plants and tile types
 				if (tileType.isTree()) {
 					treeCount++;
+					this.mapData.setSurfaceTile(x, y, Tile.TILE_GRASS, height);
 					this.mapData.setTree(x, y, decodeTree(color), getTreeAge(),
 							getGrassGrowthTreeStage());
 				} else if (tileType.isBush()) {


### PR DESCRIPTION
Noticed this when generating a map. Trees create really deep pits because the height of the tile doesn't seem to be set.
